### PR TITLE
Remove player position

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,6 @@
       width:600px;
       height:338px;
       position: relative;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
     }
     .play-button {
       position: absolute;


### PR DESCRIPTION
Removed top, left and transform css properties that positioned the
player and all contained assets on the vertical and horizontal center
of the browser.